### PR TITLE
Fix/draft invoice empty items bug

### DIFF
--- a/backend/db/queries/invoiceQueries.js
+++ b/backend/db/queries/invoiceQueries.js
@@ -196,15 +196,19 @@ const updateInvoice = async(invoice) => {
  * @throws {Error} If any error occurs during the process.
  * @returns {Object} The saved invoice item details.
  */
-const saveInvoiceItem = async(name, quantity, price, total, invoiceId) => {
+const saveInvoiceItem = async(invoiceId, item = {}) => {
+  const { name = null, quantity = null, price = null, total = null } = item;
+
   const { rows: savedItemRows } = await pool.query(
-    `INSERT INTO invoice_items(
-        name, quantity, price, total, invoice_id)
-        VALUES ($1, $2, $3, $4, $5) RETURNING id, name, quantity, price, total;`,
+    `INSERT INTO invoice_items(name, quantity, price, total, invoice_id)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, name, quantity, price, total;`,
     [name, quantity, price, total, invoiceId]
   );
+
   return savedItemRows[0];
 };
+
 
 /**
  * Fetches an invoice by its unique identifier.

--- a/backend/db/schema/03_invoice_items.sql
+++ b/backend/db/schema/03_invoice_items.sql
@@ -2,9 +2,9 @@ DROP TABLE IF EXISTS invoice_items CASCADE;
 
 CREATE TABLE invoice_items (
   id SERIAL PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
-  quantity INTEGER NOT NULL,
-  price INTEGER NOT NULL,
-  total INTEGER NOT NULL,
+  name VARCHAR(255),
+  quantity INTEGER,
+  price INTEGER,
+  total INTEGER,
   invoice_id INTEGER REFERENCES invoices (id) ON DELETE CASCADE
 );

--- a/backend/routes/invoices.js
+++ b/backend/routes/invoices.js
@@ -55,7 +55,7 @@ router.post('/', async(req, res, next) => {
         return processCustomerData(req);
       })
       .then((customer) => {
-        invoiceModel.customerId = customer.id;
+        invoiceModel.customerId = customer.id || customer.userId;
         invoiceModel.customerAddress = {
           street: customer.street,
           city: customer.city,

--- a/backend/util/invoiceHelper.js
+++ b/backend/util/invoiceHelper.js
@@ -78,7 +78,7 @@ const saveInvoiceItems = async(invoiceModel) => {
   const newItems = [];
 
   if (invoiceModel.items.length === 0) {
-    // Save a placeholder item for a draft invoice
+    // Save a placeholder item for a draft invoice with no items
     const newItem = await invoiceQueries.saveInvoiceItem(invoiceModel.invoiceId);
     console.log(`Saved new item with ID -> [${newItem.id}] to the database.`);
     newItems.push(newItem);

--- a/backend/util/invoiceHelper.js
+++ b/backend/util/invoiceHelper.js
@@ -77,21 +77,23 @@ const buildInvoiceModel = (req) => {
 const saveInvoiceItems = async(invoiceModel) => {
   const newItems = [];
 
-  for (const item of invoiceModel.items) {
-    const { name, quantity, price, total } = item;
-    
-    try {
-      const newItem = await invoiceQueries.saveInvoiceItem(name, quantity, price, total, invoiceModel.invoiceId);
+  if (invoiceModel.items.length === 0) {
+    // Save a placeholder item for a draft invoice
+    const newItem = await invoiceQueries.saveInvoiceItem(invoiceModel.invoiceId);
+    console.log(`Saved new item with ID -> [${newItem.id}] to the database.`);
+    newItems.push(newItem);
+  } else {
+    for (const item of invoiceModel.items) {
+      const newItem = await invoiceQueries.saveInvoiceItem(invoiceModel.invoiceId, item);
       console.log(`Saved new item with ID -> [${newItem.id}] to the database.`);
       newItems.push(newItem);
-    } catch (error) {
-      console.error(`Error saving invoice item: ${error}`);
     }
   }
 
   invoiceModel.items = newItems;
   return invoiceModel;
 };
+
 
 const updateInvoice = (existingInvoice, newInvoice) => {
   const updateProperty = (obj, key, newValue) => obj[key] !== newValue && (obj[key] = newValue);

--- a/backend/util/userHelper.js
+++ b/backend/util/userHelper.js
@@ -98,7 +98,6 @@ const processCustomerData = async(req) => {
       const { name, email, street, city, postCode, country, phoneNumber } = customer;
       const newUser = await userQueries.saveUser(name, email, street, city, postCode, country, phoneNumber);
       console.log(`Saved new user to the DB -> [${JSON.stringify(newUser)}]`);
-        
       return newUser;
     } else {
       throw err;

--- a/frontend/src/context/invoices.jsx
+++ b/frontend/src/context/invoices.jsx
@@ -96,8 +96,47 @@ const InvoicesProvider = ({ children }) => {
 
   // updateInvoice function
   const updateInvoice = useCallback(async (invoiceData) => {
-    console.log(invoiceData);
-  }, []);
+    if (isAuthenticated) {
+      try {
+        const response = await fetch(`/api/invoices/${invoiceData.invoiceNumber}`, {
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            userId,
+          },
+          credentials: "include", // This is important for cookies
+          method: "POST",
+          body: JSON.stringify(invoiceData ),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        const updatedInvoice = await response.json();
+
+        // Update the invoices to reflect the change
+        setInvoices((current) =>
+          current.map((invoice) =>
+            invoice.invoiceNumber === updatedInvoice.invoiceNumber
+              ? updatedInvoice
+              : invoice
+          )
+        );
+
+        // Update the singleInvoice if it's the same invoice
+        if (
+          singleInvoice &&
+          singleInvoice.invoiceNumber === updatedInvoice.invoiceNumber
+        ) {
+          setSingleInvoice(updatedInvoice);
+        }
+
+        setLastUpdateTimestamp(Date.now()); // Update the timestamp
+      } catch (error) {
+        setIsError(error.message);
+        console.log(error.message);
+      }
+    }
+  }, [singleInvoice, userId, isAuthenticated]);
 
   //updateInvoiceStatus
   const updateInvoiceStatus = useCallback(

--- a/frontend/src/hooks/use-invoice-form.js
+++ b/frontend/src/hooks/use-invoice-form.js
@@ -110,16 +110,8 @@ function useInvoiceForm(
       };
 
       await updateInvoice(newState);
-      // If the invoice is a draft, update its status to 'pending'
-      if (state.status === "draft") {
-        dispatch({
-          type: ACTION.UPDATE_FIELD,
-          field: "status",
-          value: "pending",
-        });
-        dispatch({ type: ACTION.RESET_FORM });
-        toggleModal();
-      }
+      dispatch({ type: ACTION.RESET_FORM });
+      toggleModal();
     } catch (error) {
       console.error("Error updating invoice", error);
       // Handle error, provide user feedback


### PR DESCRIPTION
Fixed 2 major bugs for creating new invoice in your POST /api/invoices route handler. See the branch -> fix/draft-invoice-empty-items-bug. It is not yet merged:

When I save/create an invoice as a draft with no items, that is invoiceModel.items is an empty array,  no id is created in the invoice_items table and no foreign key for invoice_id of the newly created draft invoice is linked to the invoice_items table. I couldn't create an item id while leaving name, quantity, price, total as null and linking the draft invoice_id as a foreign key.

Solution: Change invoice_items schema to remove NOT NULL constraint, modify saveInvoiceItem to create an item with all null properties when the items array is empty, and change saveInvoicesItems to take only an invoiceId when there are no items in a draft invoice

When I create/save a new invoice with a customer email address not found in the users table I create the customer with the available customer details in the request and set a temp password but the newly created invoice in the invoices table does not get the customer_user_id foreign key linked to the newly created customer in the users table.

Solution: Your snakeToCamel function created a bug by having two alternative forms of id (id or userId) on the same customer object in your route handler when email is present or not present in the db. I implemented a simple short circuit to check for both.